### PR TITLE
Moved a private property to header

### DIFF
--- a/IRKit/IRKit/IRNewPeripheralViewController.h
+++ b/IRKit/IRKit/IRNewPeripheralViewController.h
@@ -17,6 +17,7 @@
         UIAlertViewDelegate>
 
 @property (nonatomic, weak) id<IRNewPeripheralViewControllerDelegate> delegate;
+@property (nonatomic) UINavigationController *navController;
 
 @end
 

--- a/IRKit/IRKit/IRNewPeripheralViewController.m
+++ b/IRKit/IRKit/IRNewPeripheralViewController.m
@@ -9,7 +9,6 @@
 
 @interface IRNewPeripheralViewController ()
 
-@property (nonatomic) UINavigationController *navController;
 @property (nonatomic) id becomeActiveObserver;
 @property (nonatomic) IRKeys *keys;
 @property (nonatomic) IRPeripheral *foundPeripheral;


### PR DESCRIPTION
Moved a private property "navController" to header for extensibility.
