### PR TITLE
iOS6 support

### DIFF
--- a/IRKit/IRKit/IRViewCustomizer.m
+++ b/IRKit/IRKit/IRViewCustomizer.m
@@ -28,7 +28,9 @@
 
     __weak IRViewCustomizer *_self = self;
     _viewDidLoad = ^(UIViewController *viewController) {
-        viewController.edgesForExtendedLayout = UIRectEdgeNone;
+		if ([viewController respondsToSelector:@selector(setEdgesForExtendedLayout:)]) {
+            viewController.edgesForExtendedLayout = UIRectEdgeNone;
+        }
         viewController.view.backgroundColor   = [IRViewCustomizer defaultViewBackgroundColor];
         [_self customizeLabelFonts: viewController.view];
 
@@ -133,7 +135,9 @@
 }
 
 + (void)customizeNavigationBar:(UINavigationBar *)bar {
-    bar.barTintColor = [UIColor colorWithRed: 0xF5 / 255. green: 0xF5 / 255. blue: 0xF5 / 255. alpha: 1.0];
+    if ([bar respondsToSelector:@selector(setBarTintColor:)]) {
+        bar.barTintColor = [UIColor colorWithRed: 0xF5 / 255. green: 0xF5 / 255. blue: 0xF5 / 255. alpha: 1.0];
+    }
     bar.tintColor    = [self activeFontColor];
     bar.translucent  = NO; // if we don't want transparency
 


### PR DESCRIPTION
簡単に修正出来るものをコミットしました。
+新しいIRKitを探す->完了、と操作すると例外が発生します。
例外は、IRWifiEditViewControllerのcellForRowAtIndexPathの以下の行で発生しますが、
        IREditCell _cell = (IREditCell *)[tableView dequeueReusableCellWithIdentifier: IRKitCellIdentifierEdit];
以下のログが出るので、
*_\* Terminating app due to uncaught exception 'NSInvalidUnarchiveOperationException', reason: 'Could not instantiate class named _UITableViewCellSeparatorView'

viewDidLoadの以下の行で読み込むIREditCell.nibに原因があるのではないかと考えています。
IREditCell.nibはバイナリファイルなのでお手上げ状態です。。。
    [self.tableView registerNib: [UINib nibWithNibName: @"IREditCell" bundle: [IRHelper resources]]
         forCellReuseIdentifier: IRKitCellIdentifierEdit];
参考になれば幸いです。
(初めてgithubを使うので、使い方が間違ってたらご指摘ください。)
